### PR TITLE
アプリの雛形を実装

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,32 +1,16 @@
+import 'package:app/screens/home_screen.dart';
 import 'package:flutter/material.dart';
-import 'package:arkit_plugin/arkit_plugin.dart';
-import 'package:vector_math/vector_math_64.dart';
 
 void main() => runApp(MaterialApp(home: MyApp()));
 
-class MyApp extends StatefulWidget {
-  @override
-  _MyAppState createState() => _MyAppState();
-}
+class MyApp extends StatelessWidget {
 
-class _MyAppState extends State<MyApp> {
-  ARKitController arkitController;
 
   @override
-  void dispose() {
-    arkitController?.dispose();
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) => Scaffold(
-      appBar: AppBar(title: const Text('ARKit in Flutter')),
-      body: ARKitSceneView(onARKitViewCreated: onARKitViewCreated));
-
-  void onARKitViewCreated(ARKitController arkitController) {
-    this.arkitController = arkitController;
-    final node = ARKitNode(
-        geometry: ARKitSphere(radius: 0.1), position: Vector3(0, 0, -0.5));
-    this.arkitController.add(node);
+  Widget build(BuildContext context){
+    return MaterialApp(
+        title: 'mixture',
+        home: HomeScreen()
+    );
   }
 }

--- a/lib/screens/AR_screen.dart
+++ b/lib/screens/AR_screen.dart
@@ -1,0 +1,36 @@
+import 'dart:async';
+import 'package:flutter/services.dart';
+import 'package:flutter/material.dart';
+import 'package:arkit_plugin/arkit_plugin.dart';
+import 'package:vector_math/vector_math_64.dart';
+
+class ARScreen extends StatefulWidget {
+  static const routeName = '/ar';
+
+  const ARScreen({Key key}) : super(key: key);
+
+  @override
+  _ARScreenState createState() => _ARScreenState();
+}
+
+class _ARScreenState extends State<ARScreen> {
+  ARKitController arkitController;
+
+  @override
+  void dispose() {
+    arkitController?.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => Scaffold(
+      appBar: AppBar(title: const Text('AR Screen')),
+      body: ARKitSceneView(onARKitViewCreated: onARKitViewCreated));
+
+  void onARKitViewCreated(ARKitController arkitController) {
+    this.arkitController = arkitController;
+    final node = ARKitNode(
+        geometry: ARKitSphere(radius: 0.1), position: Vector3(0, 0, -0.5));
+    this.arkitController.add(node);
+  }
+}

--- a/lib/screens/Result_screen.dart
+++ b/lib/screens/Result_screen.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-import 'package:flutter/services.dart';
 import 'package:flutter/material.dart';
 
 class ResultScreen extends StatefulWidget{

--- a/lib/screens/Result_screen.dart
+++ b/lib/screens/Result_screen.dart
@@ -1,0 +1,29 @@
+import 'dart:async';
+import 'package:flutter/services.dart';
+import 'package:flutter/material.dart';
+
+class ResultScreen extends StatefulWidget{
+  static const routeName = '/result';
+
+  @override
+  _ResultScreenState createState() => _ResultScreenState();
+}
+
+class _ResultScreenState extends State<ResultScreen>{
+  @override
+  Widget build(BuildContext context){
+    return Scaffold(
+        appBar: AppBar(
+          title: Text("Result Screen"),
+        ),
+        body:Center(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: <Widget>[
+                Text("This is Result Screen"),
+              ],
+            )
+        )
+    );
+  }
+}

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-import 'package:flutter/services.dart';
 import 'package:flutter/material.dart';
 import 'AR_screen.dart';
 

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,0 +1,31 @@
+import 'dart:async';
+import 'package:flutter/services.dart';
+import 'package:flutter/material.dart';
+import 'AR_screen.dart';
+
+class HomeScreen extends StatefulWidget {
+  static const routeName = '/home';
+
+  @override
+  _HomeScreenState createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends State<HomeScreen> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+        appBar: AppBar(
+          title: Text("Home Screen"),
+        ),
+        body: Center(
+            child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            RaisedButton(
+                child: Text('Press This Button', style: TextStyle(fontSize: 20)),
+                onPressed: () => Navigator.of(context)
+                    .push(MaterialPageRoute(builder: (context) => ARScreen())))
+          ],
+        )));
+  }
+}


### PR DESCRIPTION
「ホーム画面→AR画面」のフローを実装

- Home_screen.dart
- AR_screen.dart

をそれぞれ作成した。
西野君が「AR画面→結果画面」のフローを実装しているようなので
このPRをマージ後に別ブランチにて『AR画面→結果画面→結果画面』のフローを完成してもらう

<ホーム画面>
![IMG_4272](https://user-images.githubusercontent.com/47593288/92324469-f4174c80-f07c-11ea-864a-8fe1ba5e3b10.PNG)

<AR画面>
![IMG_4273](https://user-images.githubusercontent.com/47593288/92324471-f679a680-f07c-11ea-87d6-2243746741e4.PNG)
